### PR TITLE
Implement Proof Key for Code Exchange auth flow for native apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,7 @@ typings/
 *.js
 !bugsnag.js
 *.d.ts
+*.map
+*.tsbuildinfo
 
 src/config/config\.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch via NPM",
+			"runtimeExecutable": "npm",
+			"runtimeArgs": [
+				"run-script",
+				"debug"
+			],
+			"port": 9229,
+			"sourceMaps": true,
+			"outFiles": ["${workspaceFolder}/**/*.js"]
+		}
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ground-truth",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2536,6 +2536,11 @@
         "uid2": "0.0.x",
         "utils-merge": "1.x.x"
       }
+    },
+    "oauth2orize-pkce": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/oauth2orize-pkce/-/oauth2orize-pkce-0.1.2.tgz",
+      "integrity": "sha1-9GEyAxPLeT9Cg0tVGf9iQP3FL/0="
     },
     "object-assign": {
       "version": "4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ground-truth",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ground-truth",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Single sign on for HackGT apps",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc -b",
     "start": "node src/app.js",
-    "report-build": "node bugsnag.js"
+    "report-build": "node bugsnag.js",
+    "debug": "node --nolazy --inspect-brk=9229 src/app.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ground-truth",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Single sign on for HackGT apps",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "mongoose": "^5.4.18",
     "morgan": "^1.9.1",
     "oauth2orize": "^1.11.0",
+    "oauth2orize-pkce": "^0.1.2",
     "passport": "^0.4.0",
     "passport-cas2": "petschekr/passport-cas",
     "passport-facebook": "^3.0.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -26,15 +26,15 @@ apiRoutes.get("/user", passport.authenticate("bearer", { session: false }), asyn
 });
 
 apiRoutes.post("/user/logout", passport.authenticate("bearer", { session: false }), postParser, async (request, response) => {
-	let rawToken = (request.headers.authorization as string).split(" ")[1];
-	let token = await AccessToken.findOne({ token: rawToken });
-	if (token) {
-		let user = await User.findOne({ uuid: token.uuid });
-		if (user) {
-			user.forceLogOut = true;
-			await user.save();
-		}
+	let user = request.user as IUser;
+	let existingTokens = await AccessToken.find({ "uuid": user.uuid });
+	for (let token of existingTokens) {
 		await token.remove();
+	}
+	let userDB = await User.findOne({ uuid: user.uuid });
+	if (userDB) {
+		userDB.forceLogOut = true;
+		await userDB.save();
 	}
 
 	response.json({ "success": true });

--- a/src/api.ts
+++ b/src/api.ts
@@ -104,6 +104,10 @@ adminRoutes.post("/app", async (request, response) => {
 		});
 		return;
 	}
+	let clientType: "private" | "public" = request.body.clientType;
+	if (clientType !== "private" && clientType !== "public") {
+		clientType = "private";
+	}
 
 	try {
 		await createNew<IOAuthClient>(OAuthClient, {
@@ -111,7 +115,8 @@ adminRoutes.post("/app", async (request, response) => {
 			clientID: crypto.randomBytes(32).toString("hex"),
 			clientSecret: crypto.randomBytes(64).toString("hex"),
 			name,
-			redirectURIs
+			redirectURIs,
+			public: clientType === "public"
 		}).save();
 		response.json({
 			"success": true

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -23,7 +23,7 @@ import {
 } from "../schema";
 import { Template } from "../templates";
 import {
-	RegistrationStrategy, strategies, validateAndCacheHostName, sendVerificationEmail
+	RegistrationStrategy, strategies
 } from "./strategies";
 
 // Passport authentication

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -183,7 +183,7 @@ server.grant(oauth2orize.grant.code((async (client: IOAuthClient, redirectURI: s
 			code,
 			redirectURI,
 			uuid: user.uuid,
-			scopes: ares.scopes || [],
+			scopes: ares.scope || [],
 			expiresAt: moment().add(60, "seconds").toDate(),
 			codeChallenge: areq.codeChallenge || undefined,
 			codeChallengeMethod: areq.codeChallengeMethod || undefined,
@@ -325,7 +325,7 @@ OAuthRouter.get("/authorize", authenticateWithRedirect, server.authorization(asy
 		}
 	}
 	let scopeNames = scopes.map(scope => scope.name);
-	request.session.scopes = scopeNames;
+	request.session.scope = scopeNames;
 
 	response.send(AuthorizeTemplate.render({
 		siteTitle: config.server.name,
@@ -364,7 +364,7 @@ OAuthRouter.post("/authorize/decision", authenticateWithRedirect, async (request
 		return;
 	}
 	let user = request.user as Model<IUser>;
-	let scopes: string[] = request.session ? request.session.scopes || [] : [];
+	let scopes: string[] = request.session ? request.session.scope || [] : [];
 	for (let scope of scopes) {
 		let scopeValue = request.body[`scope-${scope}`];
 		if (scopeValue) {
@@ -413,10 +413,8 @@ OAuthRouter.post("/authorize/decision", authenticateWithRedirect, async (request
 	next();
 }, server.decision((request, done) => {
 	let session = (request as express.Request).session;
-	let scopes: string[] = session ? session.scopes || [] : [];
-	let codeChallenge: string | undefined = session ? session.codeChallenge : undefined;
-	let codeChallengeMethod: string | undefined = session ? session.codeChallengeMethod : undefined;
-	done(null, { scopes, codeChallenge, codeChallengeMethod });
+	let scope: string[] = session ? session.scope || [] : [];
+	done(null, { scope });
 }));
 
 OAuthRouter.post("/token", passport.authenticate(["basic", "oauth2-client-password"], { session: false }), server.token(), server.errorHandler());

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -223,7 +223,7 @@ server.exchange(oauth2orize.exchange.code((async (client: IOAuthClient, code: st
 			// Private apps have already verified their client secret in verifyClient()
 			let codeVerifier: string = body.code_verifier || "";
 			if (!authCode.codeChallenge || !authCode.codeChallengeMethod || !codeVerifier) {
-				console.warn(`Missing code challenge, challenge method, or code verifier in exchange for token: ${code}`);
+				console.warn(`Missing code challenge, challenge method, or code verifier in exchange for token: ${code} (challenge: ${authCode.codeChallenge}, method: ${authCode.codeChallengeMethod}, verifier: ${codeVerifier})`);
 				done(null, false);
 				return;
 			}

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -11,6 +11,7 @@ import * as oauth2orize from "oauth2orize";
 import { BasicStrategy } from "passport-http";
 import { Strategy as BearerStrategy } from "passport-http-bearer";
 import { Strategy as ClientPasswordStrategy } from "passport-oauth2-client-password";
+import moment = require("moment");
 
 import {
 	config, mongoose, COOKIE_OPTIONS, formatName
@@ -29,7 +30,6 @@ import {
 
 // Passport authentication
 import { app } from "../app";
-import moment = require("moment");
 
 if (!config.server.isProduction) {
 	console.warn("OAuth callback(s) running in development mode");

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -28,6 +28,7 @@ import {
 
 // Passport authentication
 import { app } from "../app";
+import moment = require("moment");
 
 if (!config.server.isProduction) {
 	console.warn("OAuth callback(s) running in development mode");
@@ -172,6 +173,7 @@ server.grant(oauth2orize.grant.code(async (client: IOAuthClient, redirectURI, us
 			redirectURI,
 			uuid: user.uuid,
 			scopes: ares.scopes || [],
+			expiresAt: moment().add(60, "seconds").toDate(),
 		}).save();
 		done(null, code);
 	}
@@ -183,7 +185,7 @@ server.grant(oauth2orize.grant.code(async (client: IOAuthClient, redirectURI, us
 server.exchange(oauth2orize.exchange.code(async (client: IOAuthClient, code, redirectURI, done) => {
 	try {
 		let authCode = await AuthorizationCode.findOne({ code });
-		if (!authCode || client.clientID !== authCode.clientID || redirectURI !== authCode.redirectURI) {
+		if (!authCode || client.clientID !== authCode.clientID || redirectURI !== authCode.redirectURI || moment().isAfter(moment(authCode.expiresAt)) ) {
 			done(null, false);
 			return;
 		}

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -115,7 +115,7 @@ async function verifyClient(clientID: string, clientSecret: string, done: (err: 
 		// Private apps must have a matching client secret
 		// Public apps will verify their code challenge in the exchange step (where auth codes are exchanged for tokens)
 		if (!client || (!client.public && client.clientSecret !== clientSecret)) {
-			console.warn(`Unauthorized client: ${clientID} (secret: ${clientSecret}, public: ${client ? !!client.public : "Not found"}`);
+			console.warn(`Unauthorized client: ${clientID} (secret: ${clientSecret}, public: ${client ? !!client.public : "Not found"})`);
 			done(null, false);
 			return;
 		}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -168,6 +168,8 @@ export interface IAuthorizationCode extends RootDocument {
 	scopes: string[];
 	uuid: string;
 	expiresAt: Date;
+	codeChallenge?: string;
+	codeChallengeMethod?: "plain" | "S256";
 }
 
 export const AuthorizationCode = mongoose.model<Model<IAuthorizationCode>>("AuthorizationCode", new mongoose.Schema({
@@ -182,6 +184,8 @@ export const AuthorizationCode = mongoose.model<Model<IAuthorizationCode>>("Auth
 	scopes: [String],
 	uuid: String,
 	expiresAt: Date,
+	codeChallenge: String,
+	codeChallengeMethod: String,
 }));
 
 export interface IAccessToken extends RootDocument {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -165,6 +165,7 @@ export interface IAuthorizationCode extends RootDocument {
 	redirectURI: string;
 	scopes: string[];
 	uuid: string;
+	expiresAt: Date;
 }
 
 export const AuthorizationCode = mongoose.model<Model<IAuthorizationCode>>("AuthorizationCode", new mongoose.Schema({
@@ -178,6 +179,7 @@ export const AuthorizationCode = mongoose.model<Model<IAuthorizationCode>>("Auth
 	redirectURI: String,
 	scopes: [String],
 	uuid: String,
+	expiresAt: Date,
 }));
 
 export interface IAccessToken extends RootDocument {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -144,6 +144,7 @@ export interface IOAuthClient extends RootDocument {
 	clientID: string;
 	clientSecret: string;
 	redirectURIs: string[];
+	public?: boolean;
 }
 
 export const OAuthClient = mongoose.model<Model<IOAuthClient>>("OAuthClient", new mongoose.Schema({
@@ -157,6 +158,7 @@ export const OAuthClient = mongoose.model<Model<IOAuthClient>>("OAuthClient", ne
 	clientID: String,
 	clientSecret: String,
 	redirectURIs: [String],
+	public: Boolean,
 }));
 
 export interface IAuthorizationCode extends RootDocument {

--- a/src/ui/admin.hbs
+++ b/src/ui/admin.hbs
@@ -9,7 +9,12 @@
 					<ul>
 						<li>UUID: <strong>{{this.uuid}}</strong></li>
 						<li>Client ID: <strong>{{this.clientID}}</strong></li>
-						<li>Client Secret: <strong>{{this.clientSecret}}</strong></li>
+						{{#if this.public}}
+							<li>Client Secret: <strong>N/A</strong></li>
+						{{else}}
+							<li>Client Secret: <strong>{{this.clientSecret}}</strong></li>
+						{{/if}}
+						<li>Client Type: <strong>{{#if this.public}}Public (e.g. native app){{else}}Private (e.g. server-based){{/if}}</strong></li>
 						<li>
 							Allowed redirect URIs:
 							<ul>
@@ -32,9 +37,11 @@
 					<p class="control">
 						<button class="button is-info is-outlined edit-redirects" data-uuid="{{this.uuid}}" data-uris="{{join this.redirectURIs}}">Edit redirect URIs</button>
 					</p>
-					<p class="control">
-						<button class="button is-warning is-outlined regenerate-secret" data-uuid="{{this.uuid}}">Regenerate secret</button>
-					</p>
+					{{#if this.public}}{{else}}
+						<p class="control">
+							<button class="button is-warning is-outlined regenerate-secret" data-uuid="{{this.uuid}}">Regenerate secret</button>
+						</p>
+					{{/if}}
 					<p class="control">
 						<button class="button is-danger is-outlined delete-app" data-uuid="{{this.uuid}}">Delete</button>
 					</p>
@@ -63,6 +70,22 @@
 				<label class="label" for="redirect-uris">Redirect URIs (comma separated)</label>
 				<div class="control">
 					<input class="input" type="url" id="redirect-uris" placeholder="e.g. https://localhost:3000" />
+				</div>
+			</div>
+			<div class="field">
+				<label class="label">Client type</label>
+				<p>Private applications must pass along a <code>client_secret</code> parameter when exchanging an authorization code for a long-term access token. This can only work for mediums like server-based apps where the client secret cannot be leaked. Native apps cannot guarantee the security of their secret and so should use <a href="https://www.oauth.com/oauth2-servers/pkce" target="_blank">PKCE</a> to generate and use a per-request secret instead. Public applications <em>should not</em> store or pass along a client secret.</p>
+				<br />
+				<div class="control ">
+					<label class="radio">
+						<input type="radio" name="client-type" value="private" checked />
+						Private (e.g. server-based)
+					</label>
+					<br />
+					<label class="radio">
+						<input type="radio" name="client-type" value="public" />
+						Public (e.g. native app)
+					</label>
 				</div>
 			</div>
 			<br />

--- a/src/ui/admin.ts
+++ b/src/ui/admin.ts
@@ -84,6 +84,7 @@ namespace Admin {
 			addApplicationButton.disabled = true;
 			let nameField = document.getElementById("name") as HTMLInputElement;
 			let redirectURIsField = document.getElementById("redirect-uris") as HTMLInputElement;
+			let clientType = (document.querySelector(`input[name="client-type"]:checked`) as HTMLInputElement).value;
 
 			let name = nameField.value.trim();
 			let redirectURIs = redirectURIsField.value.trim();
@@ -96,7 +97,7 @@ namespace Admin {
 				return;
 			}
 
-			await sendRequest("/api/admin/app", { name, redirectURIs });
+			await sendRequest("/api/admin/app", { name, redirectURIs, clientType });
 		}
 		finally {
 			addApplicationButton.disabled = false;

--- a/src/ui/login.css
+++ b/src/ui/login.css
@@ -147,3 +147,7 @@ a.gatech:hover {
 .is-grouped.is-multiline > * {
 	margin-top: 12px;
 }
+
+.checkbox:hover, .radio:hover {
+	color: #aaa;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     /* Module Resolution Options */
     "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "sourceMap": true
   },
   "references": [
     { "path": "src/ui" }


### PR DESCRIPTION
Implements PKCE for use with native apps where a client secret cannot be used because it can easily be exposed. [See here](https://www.oauth.com/oauth2-servers/pkce/) for more about how PKCE works. Check out [this PKCE "playground"](https://www.oauth.com/playground/authorization-code-with-pkce.html) for an interactive way to explore how it works. (For reference: [RFC 7636](https://tools.ietf.org/html/rfc7636))

* Implements PKCE authentication for apps that are set to `public`. `private` apps (e.g. server based) are still the default and still require the usage of a client secret. PKCE supplants the client secret for native apps and basically acts as a per-request secret.
* Allows admins to choose public / private client types when creating a new app. Switching existing apps between types is intentionally not supported due to security concerns.
* Invalidate all tokens when an integrated app (like registration) calls the logout API. Previously, only the first one was invalidated
* Authorization codes are now time limited and expire after 60 seconds as recommended (required?) by the OAuth 2.0 spec

@Nicholas714 Can you test against this implementation to see if it satisfies the need of the HackGT mobile app?